### PR TITLE
Some minor tweaks to get python telfit working on python 3.7 for me

### DIFF
--- a/src/FittingUtilities.pyx
+++ b/src/FittingUtilities.pyx
@@ -4,7 +4,7 @@
       Cython code, which needs to be compiled!
 
 
-    
+
     This file is part of the TelFit program.
 
     TelFit is free software: you can redistribute it and/or modify
@@ -84,14 +84,14 @@ def CCImprove(data, model, be_safe=True, tol=0.2, debug=False):
     right = np.searchsorted(offsets, tol)
   else:
     left, right = 0, ycorr.size
-    
+
   maxindex = ycorr[left:right].argmax() + left
 
   if debug:
     return offsets[maxindex], DataStructures.xypoint(x=offsets, y=ycorr)
   else:
     return offsets[maxindex]
- 
+
 
 def Continuum(x, y, fitorder=3, lowreject=2, highreject=4, numiter=10000, function="poly"):
   """
@@ -206,7 +206,7 @@ def savitzky_golay(y, window_size, order, deriv=0, rate=1):
 
 def Iterative_SV(y, window_size, order, lowreject=3, highreject=3, numiters=100, expand=0, deriv=0, rate=1):
   """
-  Iterative version of the savitzky-golay smoothing function. 
+  Iterative version of the savitzky-golay smoothing function.
   See the documentation for savitzky_golay for details
   """
   done = False
@@ -215,13 +215,13 @@ def Iterative_SV(y, window_size, order, lowreject=3, highreject=3, numiters=100,
     iteration += 1
     done = True
     smoothed = savitzky_golay(y, window_size, order, deriv, rate)
-      
+
     reduced = y/smoothed
     sigma = np.std(reduced)
     mean = np.mean(reduced)
     badindices = np.where(np.logical_or((reduced - mean)/sigma < -lowreject, (reduced - mean)/sigma > highreject))[0]
-    
-    # Now, expand the outliers by 'expand' pixels on either 
+
+    # Now, expand the outliers by 'expand' pixels on either
     exclude  = []
     for outlier in badindices:
       for i in range(max(0, outlier - expand), min(outlier+expand+1, reduced.size)):
@@ -244,10 +244,10 @@ def FindLines(spectrum, tol=0.99, linespacing = 0.01, debug=False):
   """
   Function to find the spectral lines, given a model spectrum
   spectrum:        An xypoint instance with the model (Must be linearly spaced!)
-  tol:             The line strength needed to count the line 
+  tol:             The line strength needed to count the line
                       (0 is a strong line, 1 is weak)
-  linespacing:     The minimum spacing (nm) between two consecutive lines. 
-                      FindLines will choose the strongest line if there are 
+  linespacing:     The minimum spacing (nm) between two consecutive lines.
+                      FindLines will choose the strongest line if there are
                       several too close.
   """
   #First, convert the inputs into inputs for scipy's argrelmin
@@ -264,7 +264,7 @@ def FindLines(spectrum, tol=0.99, linespacing = 0.01, debug=False):
       lines.pop(i)
     elif debug:
       plt.plot([xval, xval], [yval-0.01, yval-0.03], 'r-')
-      
+
   if debug:
       plt.plot(spectrum.x, spectrum.y / spectrum.cont, 'k-')
       plt.title("Lines found in FittingUtilities.FindLines")
@@ -275,8 +275,8 @@ def FindLines(spectrum, tol=0.99, linespacing = 0.01, debug=False):
 
 
 
-  
-  
+
+
 
 def RebinData(data, xgrid, synphot=True):
   """
@@ -284,7 +284,7 @@ def RebinData(data, xgrid, synphot=True):
     It is designed to rebin to a courser wavelength grid, but can also
     interpolate to a finer grid.
   if synphot=True, it uses pySynphot for the rebinning, which conserves flux
-    Otherwise, it just interpolates the data and continuum which is faster 
+    Otherwise, it just interpolates the data and continuum which is faster
     but could cause problems.
   """
   if synphot:
@@ -298,7 +298,7 @@ def RebinData(data, xgrid, synphot=True):
     newdata.y = rebin_spec(data.x, data.y, xgrid)
     newdata.cont = rebin_spec(data.x, data.cont, xgrid)
     newdata.err = rebin_spec(data.x, data.err, xgrid) #Unlikely to be correct!
-    
+
     #pysynphot has edge effect issues on the first and last index.
     firstindex = np.argmin(np.abs(data.x - xgrid[0]))
     lastindex = np.argmin(np.abs(data.x - xgrid[-1]))
@@ -315,7 +315,7 @@ def RebinData(data, xgrid, synphot=True):
     newdata.err *= yunits
     newdata.cont *= yunits
     return newdata
-  
+
   else:
     data_spacing = data.x[1] - data.x[0]
     grid_spacing = xgrid[1] - xgrid[0]
@@ -337,7 +337,7 @@ def RebinData(data, xgrid, synphot=True):
         left = right
       right = np.searchsorted(data.x, (3*xgrid[-1]-xgrid[-2])/2.0)
       newdata.y[xgrid.size-1] = np.mean(data.y[left:right])
-  
+
     return newdata
 
 
@@ -351,7 +351,7 @@ def rebin_spec(wave, specin, wavnew):
   f = np.ones(len(wave))
   filt = ArraySpectralElement(wave, f)
   obs = Observation(spec, filt, binset=wavnew, force='taper')
-  
+
   return obs.binflux
 
 
@@ -366,7 +366,7 @@ def ReduceResolution(data,resolution, extend=True):
 
   WARNING! If the wavelength range is very large, it will give incorrect
     results because it uses a single Gaussian kernel for the whole range.
-    This works just fine for small wavelength ranges such as in CRIRES, 
+    This works just fine for small wavelength ranges such as in CRIRES,
     or with echelle spectra. If you have a large wavelength range, use
     ReduceResolution2!!
   """
@@ -382,15 +382,15 @@ def ReduceResolution(data,resolution, extend=True):
 
   #Extend the xy axes to avoid edge-effects, if desired
   if extend:
-    
-    before = data.y[-gaussian.size/2+1:]
-    after = data.y[:gaussian.size/2]
+
+    before = data.y[-gaussian.size//2+1:]
+    after = data.y[:gaussian.size//2]
     extended = np.r_[before, data.y, after]
 
-    first = data.x[0] - float(int(gaussian.size/2.0+0.5))*xspacing
-    last = data.x[-1] + float(int(gaussian.size/2.0+0.5))*xspacing
-    x2 = np.linspace(first, last, extended.size) 
-    
+    first = data.x[0] - float(int(gaussian.size//2.0+0.5))*xspacing
+    last = data.x[-1] + float(int(gaussian.size//2.0+0.5))*xspacing
+    x2 = np.linspace(first, last, extended.size)
+
     conv_mode = "valid"
 
   else:
@@ -400,12 +400,12 @@ def ReduceResolution(data,resolution, extend=True):
 
   newdata = data.copy()
   newdata.y = fftconvolve(extended, gaussian/gaussian.sum(), mode=conv_mode)
-    
+
   return newdata
 
 
 """
-  The following is np code to quickly convolve a spectrum 
+  The following is np code to quickly convolve a spectrum
     for ReduceResolution2. DO NOT CALL THIS DIRECTLY!
 """
 @cython.boundscheck(False)
@@ -413,20 +413,20 @@ def ReduceResolution(data,resolution, extend=True):
 cdef np.ndarray[DTYPE_t, ndim=1] convolve(np.ndarray[DTYPE_t, ndim=1] x,
                                              np.ndarray[DTYPE_t, ndim=1] y,
                                              np.ndarray[DTYPE_t, ndim=1] output,
-                                             
+
                                              double R,
                                              double nsig):
   cdef int i, n, start, end, length
   cdef double dx, sigma, total, conv, g, x0
   cdef np.ndarray[DTYPE_t, ndim=1] sig
-  
+
   dx = x[1] - x[0]    #Assumes constant x-spacing!
-  
+
   #Determine the edges
   sig = x/(2.0*R*sqrt(2.0*log(2.0)))
   n1 = np.searchsorted((x-x[0])/sig, nsig)
   n2 = np.searchsorted((x-x[x.size-1])/sig, -nsig)
-  
+
   #Convolution outer loop
   for n in range(n1, n2):
     sigma = sig[n]
@@ -434,7 +434,7 @@ cdef np.ndarray[DTYPE_t, ndim=1] convolve(np.ndarray[DTYPE_t, ndim=1] x,
     x0 = x[n]
     total = 0.0
     conv = 0.0
-    
+
     #Inner loop
     for i in range(-length, length+1):
       g = exp(-(x[n+i]-x0)**2 / (2.0*sigma**2))
@@ -443,12 +443,12 @@ cdef np.ndarray[DTYPE_t, ndim=1] convolve(np.ndarray[DTYPE_t, ndim=1] x,
     output[n] = conv/total
   return output
 
-  
+
 
 
 def ReduceResolution2(data,resolution, extend=True, nsig=5):
   """
-  This is a more accurate version of ReduceResolution. 
+  This is a more accurate version of ReduceResolution.
     It is also a bit slower, so don't use if you don't
     have to!
   """
@@ -457,7 +457,7 @@ def ReduceResolution2(data,resolution, extend=True, nsig=5):
   dx = data.x[1] - data.x[0]
   n1 = int(sig1*(nsig+1)/dx + 0.5)
   n2 = int(sig2*(nsig+1)/dx + 0.5)
-  
+
   if extend:
     #Extend array to try to remove edge effects (do so circularly)
     before = data.y[-n1:]
@@ -470,21 +470,21 @@ def ReduceResolution2(data,resolution, extend=True, nsig=5):
     x2 = np.linspace(first, last, extended.size)
     convolved = np.ones(extended.size)
     convolved = convolve(x2, extended, convolved, resolution, nsig)
-    convolved = convolved[n1:convolved.size-n2] 
+    convolved = convolved[n1:convolved.size-n2]
 
   else:
     extended = data.y.copy()
     x2 = data.x.copy()
     convolved = np.ones(extended.size)
     convolved = convolve(x2, extended, convolved, resolution, nsig)
-    
+
 
   newdata = data.copy()
   newdata.y = convolved
-  return newdata 
-  
-    
-  
+  return newdata
+
+
+
 def ReduceResolutionFFT(data, resolution, extend=True, loglinear=True, nsig=5):
     """
     Uses an fft to quickly reduce the resolution of a spectrum to the desired value
@@ -530,9 +530,9 @@ def ReduceResolutionFFT(data, resolution, extend=True, loglinear=True, nsig=5):
 
 
 
-  
 
-  
+
+
 
 
 def ReduceResolutionAndRebinData(data,resolution,xgrid):
@@ -541,5 +541,3 @@ def ReduceResolutionAndRebinData(data,resolution,xgrid):
   """
   data = ReduceResolution(data,resolution)
   return RebinData(data,xgrid)
-
-

--- a/src/TelluricFitter.py
+++ b/src/TelluricFitter.py
@@ -11,7 +11,7 @@ Usage:
       the initial guess value for that variable.
       Example: fitter.FitVariable({"ch4": 1.6, "h2o": 45.0})
   - Edit values of constant parameters: similar to FitVariable,
-      but the variables given here will not be fit. Useful for 
+      but the variables given here will not be fit. Useful for
       settings things like the telescope pointing angle, temperature,
       and pressure, which will be very well-known.
       Example: fitter.AdjustValue({"angle": 50.6})
@@ -21,15 +21,15 @@ Usage:
   - Import data (fitter.ImportData): Copy data as a class variable.
       Must be given as a DataStructures.xypoint instance
   - Perform the fit: (fitter.Fit):
-      Returns a DataStructures.xypoint instance of the model. The 
+      Returns a DataStructures.xypoint instance of the model. The
       x-values in the returned array are the same as the data.
-   - Optional: retrieve a new version of the data, which is 
+   - Optional: retrieve a new version of the data, which is
       wavelength-calibrated using the telluric lines and with
       a potentially better continuum fit using
-      data2 = fitter.data  
+      data2 = fitter.data
 
 
-      
+
 
     This file is part of the TelFit program.
 
@@ -420,15 +420,15 @@ class TelluricFitter:
                                      that the 'adjust_wave' input will determine whether the data or the
                                      telluric model is wavelength-adjusted.
         :param air_wave:  Are the wavelengths in air wavelengths? Default is True.
-        :param fit_source:  determines whether an attempt to fit the source spectrum (the spectrum of the 
-                            object you are fitting, not the telluric lines) is made. If true, this function 
+        :param fit_source:  determines whether an attempt to fit the source spectrum (the spectrum of the
+                            object you are fitting, not the telluric lines) is made. If true, this function
                             returns both the best-fit model and the source estimate. By default, it fits
                             the source spectrum with a simple smoothing kernel that works well for rapidly
                             rotating stars. However, you can give a custom source fitting function with the
                             'source_fcn' keyword.
-        :param source_fcn:  A function that takes a DataStructures.xypoint instance and any number of 
+        :param source_fcn:  A function that takes a DataStructures.xypoint instance and any number of
                             arguments/keyword arguments after it. This function should expect a spectrum of
-                            the source (without telluric lines) and attempt to fit it. 
+                            the source (without telluric lines) and attempt to fit it.
                             Warning: This function will be called in every iteration, so do not use a function
                             that takes more than ~1 second, or the telluric fit will slow down considerably!
         :param source_args: A list of arguments to give to the source function.
@@ -462,7 +462,7 @@ class TelluricFitter:
         if source_fcn is not None:
             self.source_fcn = source_fcn
             self.fit_source = True
-            
+
         if self.fit_source:
             if source_args is not None:
                 self.source_args = source_args
@@ -546,7 +546,7 @@ class TelluricFitter:
                 source.x *= u.nm.to(self.xunits)
                 model.x *= u.nm.to(self.xunits)
                 return source, model
-                
+
         else:
             if return_resolution:
                 model, R = self.GenerateModel(fitpars, return_resolution=return_resolution)
@@ -556,7 +556,7 @@ class TelluricFitter:
                 model = self.GenerateModel(fitpars, return_resolution=return_resolution)
                 model.x *= u.nm.to(self.xunits)
                 return model
-            
+
 
 
         ### -----------------------------------------------
@@ -654,10 +654,10 @@ class TelluricFitter:
         #Extract parameters from pars and const_pars. They will have variable
         #  names set from self.parnames
         fit_idx = 0
+        global resolution
         for i in range(len(self.parnames)):
             #Assign to local variables by the parameter name
-            exec ("%s = %g" % (self.parnames[i], self.const_pars[i]))
-
+            globals()[self.parnames[i]] = self.const_pars[i]
 
         wavenum_start = 1e7 / waveend
         wavenum_end = 1e7 / wavestart
@@ -1465,7 +1465,7 @@ class TelluricFitter:
         return np.where(signdiffs < 0.5)[0][0] + 1
 
 
-        
+
 def smoothing_source_fcn(data, *args, **kwargs):
     """
     Smooths the residuals after telluric division as an estimate of the star spectrum


### PR DESCRIPTION
Hey all, this is a demo of trying to run telfit on Python 3.7.  In short, it works, with only a few minor changes (floor division and something about `exec` and globals).  I haven't tested the new version with python 2, so for backwards compatibility purposes it may be worth making a "legacy" branch that preserves the existing behavior.  Or just test this with python 2 to make it interoperable.