### PR TITLE
:pushpin: Pin dependency fortranformat to <1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,7 @@ requires = ['matplotlib',
             'astropy>=0.2',
             'lockfile',
             'pysynphot>=0.7',
-            'fortranformat',
+            'fortranformat<1.0',
             'cython',
             'requests']
 


### PR DESCRIPTION
New fortranformat version introduces backwards incompatibility changes and errored on my installation.  It may work on other systems but would probably require some testing to be sure.