### PR TITLE
Avoid possible element-wise comparisons

### DIFF
--- a/src/DataStructures.py
+++ b/src/DataStructures.py
@@ -33,7 +33,7 @@ class xypoint:
              shape = (size,4). That is the shape returned by np.loadtxt
              with unpack=False.
         """
-        if array != None:
+        if array is not None:
             self.x = array[:, 0]
             self.y = array[:, 1]
             self.cont = array[:, 2]

--- a/src/MakeModel.py
+++ b/src/MakeModel.py
@@ -494,14 +494,14 @@ class Modeler:
             logging.info("All done! Output Transmission spectrum is located in the file below:\n\t\t{}".format(model_name))
 
             np.savetxt(model_name, np.transpose((wavelength[::-1], transmission[::-1])), fmt="%.8g")
-            if libfile != None:
+            if libfile is not None:
                 infile = open(libfile, "a")
                 infile.write(model_name + "\n")
                 infile.close()
 
         self.Cleanup()  #Un-lock the working directory
 
-        if wavegrid != None:
+        if wavegrid is not None:
             model = DataStructures.xypoint(x=wavelength[::-1], y=transmission[::-1])
             return FittingUtilities.RebinData(model, wavegrid)
 
@@ -555,7 +555,7 @@ class Modeler:
             v = np.r_[v, v2 + dv]
         logging.debug("v, spec size: {}, {} ", (v.size, spectrum.size))
 
-        if appendto != None and appendto[0].size > 0:
+        if appendto is not None and appendto[0].size > 0:
             old_v, old_spectrum = appendto[0], appendto[1]
             #Check for overlap (there shouldn't be any)
             last_v = old_v[-1]

--- a/src/TelluricFitter.py
+++ b/src/TelluricFitter.py
@@ -454,7 +454,7 @@ class TelluricFitter:
         self.air_wave = air_wave
 
         #Check if the user gave data to fit
-        if data != None:
+        if data is not None:
             self.ImportData(data)
         elif self.data == None:
             raise AttributeError("\n\nError! Must supply data to fit\n\n!")


### PR DESCRIPTION
In python3.8 + numpy v1.18.1 the MakeModel function raises the following Exception:

    if wavegrid != None:
    ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

This PR changes the element-wise comparisons to the "is" syntax.