### PR TITLE
Update GDAS_atmosphere.rst

### DIFF
--- a/docs/GDAS_atmosphere.rst
+++ b/docs/GDAS_atmosphere.rst
@@ -136,7 +136,7 @@ taken from a compilation of formulas for humidity, available `here`_ (hopefully)
     dew = dew[sorter]
 
     #Convert dew point temperature to ppmv
-    Pw = 6.116441 * 10**(7.591386*Temp/(Temp + 240.7263)) 
+    Pw = 6.116441 * 10**(7.591386*dew/(dew + 240.7263)) 
     h2o = Pw / (Pres-Pw) * 1e6
 
     #Unit conversion


### PR DESCRIPTION
Fix bug in converting dew point temperature to ppmv equation.
Now matching the equation that used in the code (around these [lines](https://github.com/kgullikson88/Telluric-Fitter/blob/7ae98db278525e157d2d0abaf4697e2fe778d6bc/examples/fit_example_fullechelle/Fit.py#L55))

Ne effect on the code, but, might effect user who try to use their own p-T profile.