### PR TITLE
Fix v1.4.0 packaging: version bump & pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -327,7 +327,7 @@ data_files.extend(example_files)
 
 
 setup(name='TelFit',
-      version='1.4.0',
+      version='1.4.1',
       author='Kevin Gullikson',
       author_email='kgulliks@astro.as.utexas.edu',
       url="https://telfit.readthedocs.io/",


### PR DESCRIPTION
This pull request addresses two packaging issues identified in issue #59:

1) Version string mismatch: The v1.4.0 Git tag wasn’t accompanied by a matching version="1.4.0" entry in setup.py, causing source distributions built from the tag to be named and installed as version 1.3.3. This PR bumps the version in setup.py to "1.4.1" so that python setup.py sdist and pip installations produce the correct metadata.

2) PEP 517 build support: Without a pyproject.toml, pip’s isolated builds can fail to generate the .egg-info metadata—leading to “No .egg-info directory found” errors on older or newer setuptools. This PR adds a minimal pyproject.toml specifying:

```
[build-system]
requires = ["setuptools>=42", "wheel"]
build-backend = "setuptools.build_meta"
```

This ensures robust PEP 517-compliant builds across environments.